### PR TITLE
Staged linting of css/scss, speed up eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules/
 build/
+.happypack/

--- a/.eslintrc.staged
+++ b/.eslintrc.staged
@@ -1,0 +1,7 @@
+// for linting of *only* staged files, extends our config and disables
+// the import/resolver which causes the linting to take foreeeever since
+// it traverses every referenced module
+{
+  "extends": "./.eslintrc",
+  "settings": {}
+}

--- a/.eslintrc.staged
+++ b/.eslintrc.staged
@@ -1,7 +1,0 @@
-// for linting of *only* staged files, extends our config and disables
-// the import/resolver which causes the linting to take foreeeever since
-// it traverses every referenced module
-{
-  "extends": "./.eslintrc",
-  "settings": {}
-}

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
   },
   "pre-commit": "lint-staged",
   "lint-staged": {
-    "{shared,client,server,config,internal}/**/*.js": "eslint"
+    "*.js": "eslint -c .eslintrc.staged",
+    "*.{css,scss}": "stylelint"
   },
   "dependencies": {
     "app-root-dir": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
   },
   "pre-commit": "lint-staged",
   "lint-staged": {
-    "*.js": "eslint -c .eslintrc.staged",
-    "*.{css,scss}": "stylelint"
+    "*.{js,jsx}": "./node_modules/.bin/eslint",
+    "*.{css,scss}": "./node_modules/.bin/stylelint"
   },
   "dependencies": {
     "app-root-dir": "1.0.2",


### PR DESCRIPTION
By not resolving referenced modules, linting of staged files is much faster, although it could miss some errors.

Before 🐌
```bash
> time gc
git commit -v  5.57s user 0.34s system 110% cpu 5.363 total
```

After 🐰
```bash
> time gc
git commit -v  1.45s user 0.19s system 105% cpu 1.560 total
```