### PR TITLE
Add `sourcemap` config value for choosing which one webpack uses

### DIFF
--- a/config/values.js
+++ b/config/values.js
@@ -26,6 +26,14 @@ const values = {
     helmet: true,
   },
 
+  // sourcemaps, switch between faster build times and more detailed stack traces
+  // source-map -- most detailed, slowest
+  // eval-source-map -- almost as good, faster in rebuilds
+  // eval-cheap-module-source-map -- only lines
+  // eval-cheap-source-map -- only lines, not for modules
+  // eval -- best perf but only source per module
+  sourcemap: 'source-map',
+
   // The public facing url of the app
   publicUrl: EnvVars.string('PUBLIC_URL'),
 

--- a/config/values.js
+++ b/config/values.js
@@ -26,14 +26,6 @@ const values = {
     helmet: true,
   },
 
-  // sourcemaps, switch between faster build times and more detailed stack traces
-  // source-map -- most detailed, slowest
-  // eval-source-map -- almost as good, faster in rebuilds
-  // eval-cheap-module-source-map -- only lines
-  // eval-cheap-source-map -- only lines, not for modules
-  // eval -- best perf but only source per module
-  sourcemap: 'source-map',
-
   // The public facing url of the app
   publicUrl: EnvVars.string('PUBLIC_URL'),
 
@@ -174,6 +166,11 @@ const values = {
 
   // Where does our build output live?
   buildOutputPath: './build',
+
+  // Which sourcemaps to use in development mode.
+  // See https://webpack.js.org/configuration/devtool/ for latest info
+  // about build speeds vs accuracity.
+  sourcemap: 'eval-source-map',
 
   // Do you want to included source maps for optimised builds of the client
   // bundle?

--- a/internal/webpack/configFactory.js
+++ b/internal/webpack/configFactory.js
@@ -150,7 +150,7 @@ export default function webpackConfigFactory(buildOptions) {
         || config('includeSourceMapsForOptimisedClientBundle'),
       )(
       // Produces an external source map (lives next to bundle output files).
-      'source-map',
+      config('sourcemap') || 'eval',
       // Produces no source map.
       'hidden-source-map',
     ),


### PR DESCRIPTION
Since sourcamaps can really slow down the build step, add possible values to config with some comments