### PR TITLE
Add Sketch keyboard shortcut to toggle vertical grid

### DIFF
--- a/shared/components/grid-overlay/GridOverlay.js
+++ b/shared/components/grid-overlay/GridOverlay.js
@@ -44,6 +44,16 @@ export default class GridOverlay extends Component {
    */
   componentDidMount() {
     this.setup();
+
+    document.addEventListener('keydown', this.keydownRef = this.onKeyDown);
+  }
+
+  /**
+   * Remove the key event.
+   * @return {void}
+   */
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.keydownRef);
   }
 
   /**
@@ -54,6 +64,18 @@ export default class GridOverlay extends Component {
    */
   componentWillReceiveProps(props) {
     this.setup(props);
+  }
+
+  /**
+   * Let's display the grid with the same shortcut as Sketch.
+   * Because why not
+   * @return {void}
+   */
+  @autobind
+  onKeyDown(e) {
+    if (e.ctrlKey && e.keyCode === 76) {
+      this.onToggleVertical();
+    }
   }
 
   /**


### PR DESCRIPTION
Working with Sketch, I use all the time the ctrl + L shortcut to toggle the grid, I thought it could be a good idea to have the same shortcut working on the starter kit.