### PR TITLE
segment has (more) flexible dimensions

### DIFF
--- a/shared/styles/mixins.scss
+++ b/shared/styles/mixins.scss
@@ -61,18 +61,20 @@
   }
 }
 
-@mixin segment($padding-mobile: $segment-padding-mobile, $padding: $segment-padding) {
-  padding-top: $padding-mobile;
-  padding-bottom: $padding-mobile;
+// segment customisable per-component / instance rather than being forced to work around defaults.
+
+@mixin segment($padding-top: $segment-padding, $padding-bottom: $segment-padding, $padding-top-mobile: $segment-padding-mobile, $padding-bottom-mobile: $segment-padding-mobile) {
+  padding-top: $padding-top-mobile;
+  padding-bottom: $padding-bottom-mobile;
 
   @media (min-width: $min-tablet) {
-    padding-top: percentage($padding/$limit);
-    padding-bottom: percentage($padding/$limit);
+    padding-top: percentage(strip-unit($padding-top)/strip-unit($limit));
+    padding-bottom: percentage(strip-unit($padding-bottom)/strip-unit($limit));
   }
 
   @media (min-width: $limit) {
-    padding-top: $padding;
-    padding-bottom: $padding;
+    padding-top: strip-unit($padding-top) * 1px;
+    padding-bottom: strip-unit($padding-bottom) * 1px;
   }
 }
 
@@ -82,16 +84,16 @@
   padding: 0 $container-gutter-mobile;
   max-width: $page-width + $container-gutter-mobile * 1;
 
-  @include viewport(340px) {
+  @media (min-width: 340px) {
     max-width: $page-width + $container-gutter-mobile * 2;
   }
 
-  @include viewport(tablet) {
+  @media (min-width: $min-tablet) {
     padding: 0 $container-gutter-tablet;
     max-width: $page-width + $container-gutter-tablet * 2;
   }
 
-  @include viewport(desktop) {
+  @media (min-width: $min-desktop) {
     padding: 0 $container-gutter-desktop;
     max-width: $page-width + $container-gutter-desktop * 2;
   }


### PR DESCRIPTION
- can now set padding top / bottom values (computed as percentage) independently to fit a component rather than being constrained by defaults
- also set mobile (i.e < `$min-tablet`) values
- unitless vars (but computation assumes percentage-based pixels)

examples:
- defaults `@include segment;`
- set non-default top & bottom padding `@include segment(120px,160px);`
- set mobile padding `@include segment(120px,70px, 40px, 30px);`
- mix values `@include segment($gutter * 4, 80, $gutter / 2, 45px);`