### PR TITLE
Add a HEROKU_DEVTOOLS flag to display devtools

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -20,6 +20,9 @@ PORT=3000
 # Notifier
 NOTIFIER=warn
 
+# Toggle devtools on heroku
+HEROKU_DEVTOOLS=false
+
 # The port on which to run the client bundle dev server (i.e. used during
 # development only).
 CLIENT_DEV_PORT=7331

--- a/config/values.js
+++ b/config/values.js
@@ -26,6 +26,8 @@ const values = {
     helmet: true,
     // Google Analytics is initialized on the client.
     gaId: true,
+    // Expose heroku devtools flag
+    herokuDevtools: true,
   },
 
   // The public facing url of the app
@@ -53,6 +55,9 @@ const values = {
 
   // Enable node-notifier?
   notifier: EnvVars.string('NOTIFIER', 'warn'),
+
+  // Toggle devtools on heroku
+  herokuDevtools: EnvVars.string('HEROKU_DEVTOOLS', false),
 
   // Disable server side rendering?
   disableSSR: false,

--- a/shared/components/devtools/DevTools.js
+++ b/shared/components/devtools/DevTools.js
@@ -2,8 +2,9 @@ import React, { Component } from 'react';
 import { observable } from 'mobx';
 import { observer } from 'mobx-react';
 import autobind from 'core-decorators/lib/autobind';
+import config from 'utils/config';
 
-const showDevTools = process.env.BUILD_FLAG_IS_DEV === 'true';
+const showDevTools = process.env.BUILD_FLAG_IS_DEV === 'true' || config('herokuDevtools');
 const MobxDevTools = showDevTools && require('mobx-react-devtools').default;
 const GridOverlay = showDevTools && require('components/grid-overlay').default;
 


### PR DESCRIPTION
HEROKU_DEVTOOLS=true to heroku let you display devtools `ctrl + k` and/or grid `ctrl + l`.