### PR TITLE
Standarise

### DIFF
--- a/shared/components/analytics/index.js
+++ b/shared/components/analytics/index.js
@@ -1,1 +1,1 @@
-export { default } from './Analytics';
+export default from './Analytics';

--- a/shared/components/app-layout/AppLayout.js
+++ b/shared/components/app-layout/AppLayout.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import 'styles/fonts.css';
 
 import s from './AppLayout.scss';
-import 'styles/fonts.css';
 
 export default class AppLayout extends Component {
 

--- a/shared/components/app-layout/AppLayout.js
+++ b/shared/components/app-layout/AppLayout.js
@@ -11,9 +11,11 @@ export default class AppLayout extends Component {
   };
 
   render() {
+    const { children } = this.props;
+
     return (
       <div className={s.layout}>
-        {this.props.children}
+        {children}
       </div>
     );
   }

--- a/shared/components/app-layout/AppLayout.js
+++ b/shared/components/app-layout/AppLayout.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+
 import s from './AppLayout.scss';
 import 'styles/fonts.css';
 

--- a/shared/components/app-layout/Content.js
+++ b/shared/components/app-layout/Content.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import s from './Content.scss';
 
 export default function Content({ children }) {

--- a/shared/components/button/Button.js
+++ b/shared/components/button/Button.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+
 import s from './Button.scss';
 
 /**

--- a/shared/components/button/Button.scss
+++ b/shared/components/button/Button.scss
@@ -4,7 +4,7 @@ $btn-height: 40px;
 $btn-border-width: 2px;
 
 .button {
-  @include reset-button();
+  @include reset-button;
 
   display: inline-flex;
   position: relative;

--- a/shared/components/container/Container.js
+++ b/shared/components/container/Container.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import s from './Container.scss';
 
 const Container = ({ children }) => (

--- a/shared/components/container/Container.scss
+++ b/shared/components/container/Container.scss
@@ -1,7 +1,7 @@
 @import '~styles/config';
 
 .container {
-  @include container();
+  @include container;
 
   .full {
     max-width: none;

--- a/shared/components/grid-overlay/GridOverlay.js
+++ b/shared/components/grid-overlay/GridOverlay.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { observable } from 'mobx';
 import { observer } from 'mobx-react';
 import autobind from 'core-decorators/lib/autobind';
+
 import s from './GridOverlay.scss';
 
 // Key to store visibility state of the grid overlay

--- a/shared/components/header/Header.js
+++ b/shared/components/header/Header.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+
 import UenoLogoSvg from 'assets/images/ueno-logo.svg';
+
 import s from './Header.scss';
 
 export default class Header extends Component {

--- a/shared/components/header/Header.scss
+++ b/shared/components/header/Header.scss
@@ -8,7 +8,7 @@
   background-color: #fff;
 
   &__container {
-    @include container();
+    @include container;
   }
 
   &__content {

--- a/shared/components/header/Header.spec.js
+++ b/shared/components/header/Header.spec.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Link } from 'react-router-dom';
+
 import UenoLogoSvg from 'assets/images/ueno-logo.svg';
+
 import Header from 'components/header';
 
 it('contains the Ueno. logo', () => {

--- a/shared/components/navigation/Navigation.js
+++ b/shared/components/navigation/Navigation.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+
 import s from './Navigation.scss';
 
 export default class Navigation extends Component {

--- a/shared/components/segment/Segment.js
+++ b/shared/components/segment/Segment.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+
 import Container from 'components/container';
+
 import s from './Segment.scss';
 
 /**

--- a/shared/index.js
+++ b/shared/index.js
@@ -12,6 +12,7 @@ import Analytics from 'components/analytics';
 
 // Routes
 import Home from './routes/home';
+import Grid from './routes/grid';
 import About from './routes/about';
 import Planets from './routes/planets';
 import NotFound from './routes/not-found';
@@ -23,6 +24,7 @@ export default function App() {
       <Header>
         <Navigation>
           <Link to="/">Home</Link>
+          <Link to="/grid">Grid</Link>
           <Link to="/planets">Planets</Link>
           <Link to="/about">About</Link>
         </Navigation>
@@ -31,6 +33,7 @@ export default function App() {
         <Route component={Analytics} />
         <Switch>
           <Route exact path="/" component={Home} />
+          <Route exact path="/grid" component={Grid} />
           <Route exact path="/about" component={About} />
           <Route path="/planets" component={Planets} />
           <Route component={NotFound} />

--- a/shared/routes/about/About.js
+++ b/shared/routes/about/About.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
-import Segment from 'components/segment';
 import Helmet from 'react-helmet';
+
+import Segment from 'components/segment';
 
 export default class About extends Component {
   render() {

--- a/shared/routes/about/index.js
+++ b/shared/routes/about/index.js
@@ -1,9 +1,1 @@
-// import { createAsyncComponent } from 'react-async-component';
-//
-// export default createAsyncComponent({
-//   resolve: () => System.import('./About'),
-//   ssrMode: 'boundary',
-//   name: 'About',
-// });
-
 export default from './About';

--- a/shared/routes/grid/Grid.js
+++ b/shared/routes/grid/Grid.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react';
+import Helmet from 'react-helmet';
+
+import GridHelper from './components/grid';
+
+export default class Grid extends Component {
+  render() {
+    return (
+      <div>
+        <Helmet title="Grid" />
+
+        <GridHelper />
+      </div>
+    );
+  }
+}

--- a/shared/routes/grid/components/grid/Grid.js
+++ b/shared/routes/grid/components/grid/Grid.js
@@ -1,0 +1,69 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import s from './Grid.scss';
+
+export default class Grid extends Component {
+
+  render() {
+    return (
+      <div className={s.grid}>
+        <div className={s.grid__row}>
+          <div className={s(s.grid__tenCol, s.grid__offsetLeftOne)}>
+            <div className={s.grid__inside} />
+          </div>
+        </div>
+
+        <div className={s.grid__row}>
+          <div className={s.grid__twoCol}>
+            <div className={s.grid__inside} />
+          </div>
+
+          <div className={s.grid__twoCol}>
+            <div className={s.grid__inside} />
+          </div>
+
+          <div className={s.grid__twoCol}>
+            <div className={s.grid__inside} />
+          </div>
+
+          <div className={s.grid__twoCol}>
+            <div className={s.grid__inside} />
+          </div>
+
+          <div className={s.grid__twoCol}>
+            <div className={s.grid__inside} />
+          </div>
+
+          <div className={s.grid__twoCol}>
+            <div className={s.grid__inside} />
+          </div>
+        </div>
+
+        <div className={s.grid__row}>
+          <div className={s(s.grid__threeCol, s.grid__offsetLeftOne)}>
+            <div className={s.grid__inside} />
+          </div>
+
+          <div className={s(s.grid__threeCol, s.grid__offsetLeftOne)}>
+            <div className={s.grid__inside} />
+          </div>
+
+          <div className={s(s.grid__threeCol, s.grid__offsetLeftOne)}>
+            <div className={s.grid__inside} />
+          </div>
+        </div>
+
+        <div className={s.grid__row}>
+          <div className={s(s.grid__fourCol, s.grid__offsetLeftOne, s.grid__offsetRightOne)}>
+            <div className={s.grid__inside} />
+          </div>
+
+          <div className={s(s.grid__fourCol, s.grid__offsetLeftOne, s.grid__offsetRightOne)}>
+            <div className={s.grid__inside} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/shared/routes/grid/components/grid/Grid.js
+++ b/shared/routes/grid/components/grid/Grid.js
@@ -62,6 +62,8 @@ export default class Grid extends Component {
             <div className={s.grid__inside} />
           </div>
         </div>
+
+        <div className={s.grid__spacer} />
       </div>
     );
   }

--- a/shared/routes/grid/components/grid/Grid.js
+++ b/shared/routes/grid/components/grid/Grid.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 
 import s from './Grid.scss';
 

--- a/shared/routes/grid/components/grid/Grid.scss
+++ b/shared/routes/grid/components/grid/Grid.scss
@@ -1,0 +1,128 @@
+@import '~styles/config';
+
+@mixin font() {
+  @include responsive-font(14, 14);
+
+  color: $color-light;
+}
+
+@mixin text-col($text) {
+  @include font;
+
+  content: $text;
+
+  position: absolute;
+  top: 10px;
+  left: 25px;
+  right: 25px;
+}
+
+.grid {
+  @include container;
+
+  position: relative;
+
+  margin-top: 140px;
+
+  box-shadow: 0 0 0 1px $color-placeholder;
+
+  &::after {
+    @include font;
+
+    content: '@include container;';
+
+    position: absolute;
+    top: 10px;
+    left: 10px;
+  }
+
+  &::before {
+    content: '';
+
+    display: block;
+
+    padding-top: 50px;
+  }
+
+  &__row {
+    @include make-row;
+
+    position: relative;
+
+    padding-top: 50px;
+    padding-bottom: 15px;
+    margin-bottom: 15px;
+
+    box-shadow: 0 0 0 1px $color-placeholder;
+
+    &::after {
+      @include font;
+
+      content: '@include make-row;';
+
+      position: absolute;
+      top: 10px;
+      left: 10px;
+    }
+  }
+
+  &__inside {
+    height: 100px;
+
+    background-color: $color-placeholder;
+  }
+
+  // Offsets examples
+  &__offsetLeftOne {
+    @include make-offset-left(1);
+  }
+
+  &__offsetRightOne {
+    @include make-offset-right(1);
+  }
+
+  &__offsetRightTwo {
+    @include make-offset-right(2);
+  }
+
+  // Columns examples
+  &__twoCol {
+    @include make-col(2);
+
+    position: relative;
+
+    &::after {
+      @include text-col('@include make-col(2);');
+    }
+  }
+
+  &__threeCol {
+    @include make-col(3);
+
+    position: relative;
+
+    &::after {
+      @include text-col('@include make-col(3); @include make-offset-left(1);');
+    }
+  }
+
+  &__fourCol {
+    @include make-col(4);
+
+    position: relative;
+
+    &::after {
+      @include text-col('@include make-col(4); @include make-offset-left(1); @include make-offset-right(1);');
+    }
+  }
+
+  &__tenCol {
+    @include make-col(10);
+
+    position: relative;
+
+    &::after {
+      @include text-col('@include make-col(10); @include make-offset-left(1);');
+    }
+  }
+}

--- a/shared/routes/grid/components/grid/Grid.scss
+++ b/shared/routes/grid/components/grid/Grid.scss
@@ -1,20 +1,15 @@
 @import '~styles/config';
 
-@mixin font() {
+@mixin text-col($text, $left: 25px, $right: 25px) {
   @include responsive-font(14, 14);
 
-  color: $color-light;
-}
-
-@mixin text-col($text) {
-  @include font;
-
   content: $text;
-
   position: absolute;
   top: 10px;
-  left: 25px;
-  right: 25px;
+  left: $left;
+  right: $right;
+
+  color: $color-light;
 }
 
 .grid {
@@ -27,13 +22,7 @@
   box-shadow: 0 0 0 1px $color-placeholder;
 
   &::after {
-    @include font;
-
-    content: '@include container;';
-
-    position: absolute;
-    top: 10px;
-    left: 10px;
+    @include text-col('@include container;', 10px, 10px);
   }
 
   &::before {
@@ -56,13 +45,7 @@
     box-shadow: 0 0 0 1px $color-placeholder;
 
     &::after {
-      @include font;
-
-      content: '@include make-row;';
-
-      position: absolute;
-      top: 10px;
-      left: 10px;
+      @include text-col('@include make-row;', 10px, 10px);
     }
   }
 

--- a/shared/routes/grid/components/grid/Grid.scss
+++ b/shared/routes/grid/components/grid/Grid.scss
@@ -66,6 +66,10 @@
     }
   }
 
+  &__spacer {
+    height: 35px;
+  }
+
   &__inside {
     height: 100px;
 

--- a/shared/routes/grid/components/grid/Grid.scss
+++ b/shared/routes/grid/components/grid/Grid.scss
@@ -9,6 +9,7 @@
   left: $left;
   right: $right;
 
+  font-family: monospace;
   color: $color-light;
 }
 

--- a/shared/routes/grid/components/grid/Grid.scss
+++ b/shared/routes/grid/components/grid/Grid.scss
@@ -1,6 +1,6 @@
 @import '~styles/config';
 
-@mixin text-col($text, $left: 25px, $right: 25px) {
+@mixin placeholder($text, $left: 25px, $right: 25px) {
   @include responsive-font(14, 14);
 
   content: $text;
@@ -22,7 +22,7 @@
   box-shadow: 0 0 0 1px $color-placeholder;
 
   &::after {
-    @include text-col('@include container;', 10px, 10px);
+    @include placeholder('@include container;', 10px, 10px);
   }
 
   &::before {
@@ -45,7 +45,7 @@
     box-shadow: 0 0 0 1px $color-placeholder;
 
     &::after {
-      @include text-col('@include make-row;', 10px, 10px);
+      @include placeholder('@include make-row;', 10px, 10px);
     }
   }
 
@@ -79,7 +79,7 @@
     position: relative;
 
     &::after {
-      @include text-col('@include make-col(2);');
+      @include placeholder('@include make-col(2);');
     }
   }
 
@@ -89,7 +89,7 @@
     position: relative;
 
     &::after {
-      @include text-col('@include make-col(3); @include make-offset-left(1);');
+      @include placeholder('@include make-col(3); @include make-offset-left(1);');
     }
   }
 
@@ -99,7 +99,7 @@
     position: relative;
 
     &::after {
-      @include text-col('@include make-col(4); @include make-offset-left(1); @include make-offset-right(1);');
+      @include placeholder('@include make-col(4); @include make-offset-left(1); @include make-offset-right(1);');
     }
   }
 
@@ -109,7 +109,7 @@
     position: relative;
 
     &::after {
-      @include text-col('@include make-col(10); @include make-offset-left(1);');
+      @include placeholder('@include make-col(10); @include make-offset-left(1);');
     }
   }
 }

--- a/shared/routes/grid/components/grid/index.js
+++ b/shared/routes/grid/components/grid/index.js
@@ -1,0 +1,1 @@
+export default from './Grid';

--- a/shared/routes/grid/index.js
+++ b/shared/routes/grid/index.js
@@ -1,0 +1,1 @@
+export default from './Grid';

--- a/shared/routes/home/Home.js
+++ b/shared/routes/home/Home.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import Helmet from 'react-helmet';
+
 import Segment from 'components/segment';
 import Button from 'components/button';
 

--- a/shared/routes/home/index.js
+++ b/shared/routes/home/index.js
@@ -1,9 +1,1 @@
-// import { createAsyncComponent } from 'react-async-component';
-//
-// export default createAsyncComponent({
-//   resolve: () => System.import('./Home'),
-//   ssrMode: 'boundary',
-//   name: 'Home',
-// });
-
 export default from './Home';

--- a/shared/routes/not-found/NotFound.js
+++ b/shared/routes/not-found/NotFound.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
+
 import Segment from 'components/segment';
 
 export default class NotFound extends Component {

--- a/shared/routes/planets/details/PlanetsDetail.js
+++ b/shared/routes/planets/details/PlanetsDetail.js
@@ -4,6 +4,7 @@ import { inject } from 'mobx-react';
 import { withJob } from 'react-jobs';
 import { Link } from 'react-router-dom';
 import Helmet from 'react-helmet';
+
 import Segment from 'components/segment';
 
 import RelatedPlanets from './components/related-planets';

--- a/shared/routes/planets/index.js
+++ b/shared/routes/planets/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Switch, Route, Redirect } from 'react-router-dom';
+
 import PlanetsList from './list';
 import PlanetsDetail from './details';
 

--- a/shared/routes/planets/list/PlanetsList.js
+++ b/shared/routes/planets/list/PlanetsList.js
@@ -5,9 +5,10 @@ import { computed } from 'mobx';
 import { withJob } from 'react-jobs';
 import { Link } from 'react-router-dom';
 import Helmet from 'react-helmet';
+import { autobind } from 'core-decorators';
+
 import Segment from 'components/segment';
 import Button from 'components/button';
-import { autobind } from 'core-decorators';
 
 const LoadingComponent = () => (
   <Segment>

--- a/shared/styles/base.scss
+++ b/shared/styles/base.scss
@@ -45,7 +45,7 @@ body { // stylelint-disable-line
   font-family: $font-family;
   font-size: $font-size;
   line-height: $line-height;
-  color: $font-color;
+  color: $color-default;
 
   // iOS on orientation change
   text-size-adjust: 100%;

--- a/shared/styles/grid.scss
+++ b/shared/styles/grid.scss
@@ -1,3 +1,12 @@
+// Helper to convert straight number to percentage
+@function convertify($number) {
+  @if type-of($number) == 'number' and unitless($number) {
+    @return percentage($number/12);
+  }
+
+  @return $number;
+}
+
 // Rows
 @mixin make-row($direction: ltr, $align: stretch, $justify: flex-start, $grid-gutter: $gutter, $wrap: wrap) {
   display: flex;
@@ -16,7 +25,6 @@
   @else {
     flex-direction: row-reverse;
   }
-
 }
 
 // Columns
@@ -27,5 +35,14 @@
   padding-left: $grid-gutter/2;
   padding-right: $grid-gutter/2;
 
-  width: $width;
+  width: convertify($width);
+}
+
+// Offsets
+@mixin make-offset-left($offset: percentage(1/12)) {
+  margin-left: convertify($offset);
+}
+
+@mixin make-offset-right($offset: percentage(1/12)) {
+  margin-right: convertify($offset);
 }

--- a/shared/styles/mixins.scss
+++ b/shared/styles/mixins.scss
@@ -62,7 +62,6 @@
 }
 
 // segment customisable per-component / instance rather than being forced to work around defaults.
-
 @mixin segment($padding-top: $segment-padding, $padding-bottom: $segment-padding, $padding-top-mobile: $segment-padding-mobile, $padding-bottom-mobile: $segment-padding-mobile) {
   padding-top: $padding-top-mobile;
   padding-bottom: $padding-bottom-mobile;

--- a/shared/styles/variables.scss
+++ b/shared/styles/variables.scss
@@ -10,12 +10,12 @@ $limit: $page-width + ($container-gutter-desktop * 2);
 // Fonts
 $font-family: 'Roboto', sans-serif;
 $font-size: 16px;
-$font-color: #333;
-$font-color-light: #777;
-$font-color-dark: #111;
 $line-height: 1.5;
 
 // Colors
+$color-default: #333;
+$color-light: #777;
+$color-dark: #111;
 $color-pink: #aa0078;
 $color-primary: $color-pink;
 $color-placeholder: #ddd;


### PR DESCRIPTION
- Rename related colors' variables with the same prefix.
- Standarise imports on top of each file, separated in 4 groups (`dependencies`, `assets`, `global components`, `local components/stylesheets`)
- Add 2 news mixins (`make-offset-left`, `make-offset-right`), add a new feature as a shorthand to `make-col` mixin to only pass a number and calculate the percentage related -> `make-col(2)` = `make-col(percentage(2/12)`.
- Add a grid route to explain the layout and the new different way to use grid's mixins.
- Clean some stuff here and there.