### PR TITLE
Sass changes

### DIFF
--- a/shared/components/container/Container.scss
+++ b/shared/components/container/Container.scss
@@ -6,11 +6,11 @@
   .full {
     max-width: none;
 
-    @include viewport(tablet) {
+    @media (min-width: $min-tablet) {
       max-width: none;
     }
 
-    @include viewport(desktop) {
+    @media (min-width: $min-desktop) {
       max-width: none;
     }
   }

--- a/shared/components/grid-overlay/GridOverlay.scss
+++ b/shared/components/grid-overlay/GridOverlay.scss
@@ -1,9 +1,9 @@
 @import '~styles/config';
 
 :root {
-  --grid-column-count: 12;
-  --grid-baseline: 16px;
-  --grid-baseline-calc: 16;
+  --grid-column-count: $grid-column-count;
+  --grid-baseline: $grid-baseline;
+  --grid-baseline-calc: unitless($grid-baseline);
 }
 
 .grid {
@@ -40,13 +40,13 @@
   }
 
   &__row {
-    @include make-row;
+    @include grid-row;
 
     height: 100%;
   }
 
   &__column {
-    @include make-col(calc(100% / var(--grid-column-count, 12)));
+    @include grid-col(calc(100% / var(--grid-column-count, #{$grid-column-count})));
 
     position: relative;
     height: 100%;
@@ -139,7 +139,7 @@
 
 // Polyfill for browsers without css variables
 // Like Safari 9
-@for $i from 1 through 12 {
+@for $i from 1 through $grid-column-count {
   [data-columns='#{$i}'] .grid__column {
     min-width: 100% / $i;
   }

--- a/shared/components/heading/Heading.js
+++ b/shared/components/heading/Heading.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import s from './Heading.scss';
+
+const Heading = ({ children }) => (
+  <h1 className={s.heading}>
+    {children}
+  </h1>
+);
+
+Heading.propTypes = {
+  children: PropTypes.node,
+};
+
+export default Heading;

--- a/shared/components/heading/Heading.scss
+++ b/shared/components/heading/Heading.scss
@@ -1,0 +1,5 @@
+@import '~styles/config';
+
+.heading {
+  @include responsive-font(26, 52);
+}

--- a/shared/components/heading/index.js
+++ b/shared/components/heading/index.js
@@ -1,0 +1,1 @@
+export { default } from './Heading';

--- a/shared/routes/grid/components/grid/Grid.scss
+++ b/shared/routes/grid/components/grid/Grid.scss
@@ -35,7 +35,7 @@
   }
 
   &__row {
-    @include make-row;
+    @include grid-row;
 
     position: relative;
 
@@ -46,7 +46,7 @@
     box-shadow: 0 0 0 1px $color-placeholder;
 
     &::after {
-      @include placeholder('@include make-row;', 10px, 10px);
+      @include placeholder('@include grid-row;', 10px, 10px);
     }
   }
 
@@ -62,55 +62,55 @@
 
   // Offsets examples
   &__offsetLeftOne {
-    @include make-offset-left(1);
+    @include grid-offset-left(1);
   }
 
   &__offsetRightOne {
-    @include make-offset-right(1);
+    @include grid-offset-right(1);
   }
 
   &__offsetRightTwo {
-    @include make-offset-right(2);
+    @include grid-offset-right(2);
   }
 
   // Columns examples
   &__twoCol {
-    @include make-col(2);
+    @include grid-col(2);
 
     position: relative;
 
     &::after {
-      @include placeholder('@include make-col(2);');
+      @include placeholder('@include grid-col(2);');
     }
   }
 
   &__threeCol {
-    @include make-col(3);
+    @include grid-col(3);
 
     position: relative;
 
     &::after {
-      @include placeholder('@include make-col(3); @include make-offset-left(1);');
+      @include placeholder('@include grid-col(3); @include grid-offset-left(1);');
     }
   }
 
   &__fourCol {
-    @include make-col(4);
+    @include grid-col(4);
 
     position: relative;
 
     &::after {
-      @include placeholder('@include make-col(4); @include make-offset-left(1); @include make-offset-right(1);');
+      @include placeholder('@include grid-col(4); @include grid-offset-left(1); @include grid-offset-right(1);');
     }
   }
 
   &__tenCol {
-    @include make-col(10);
+    @include grid-col(10);
 
     position: relative;
 
     &::after {
-      @include placeholder('@include make-col(10); @include make-offset-left(1);');
+      @include placeholder('@include grid-col(10); @include grid-offset-left(1);');
     }
   }
 }

--- a/shared/routes/grid/components/grid/Grid.scss
+++ b/shared/routes/grid/components/grid/Grid.scss
@@ -1,7 +1,7 @@
 @import '~styles/config';
 
 @mixin placeholder($text, $left: 25px, $right: 25px) {
-  @include responsive-font(14, 14);
+  @include responsive-font(12, 14);
 
   content: $text;
   position: absolute;

--- a/shared/routes/home/Home.js
+++ b/shared/routes/home/Home.js
@@ -3,6 +3,7 @@ import Helmet from 'react-helmet';
 import config from 'utils/config';
 
 import Segment from 'components/segment';
+import Heading from 'components/heading';
 import Button from 'components/button';
 
 export default class Home extends Component {
@@ -12,7 +13,7 @@ export default class Home extends Component {
         <Helmet title="Home" />
 
         <Segment>
-          <h1>{config('welcomeMessage')}</h1>
+          <Heading>{config('welcomeMessage')}</Heading>
         </Segment>
 
         <Segment>

--- a/shared/styles/base.scss
+++ b/shared/styles/base.scss
@@ -28,6 +28,9 @@ html { // stylelint-disable-line
   overflow-y: scroll;
 
   box-sizing: border-box;
+
+  -webkit-font-smoothing: antialiased; // stylelint-disable-line
+  -moz-osx-font-smoothing: grayscale; // stylelint-disable-line
 }
 
 // inherited from <html>

--- a/shared/styles/base.scss
+++ b/shared/styles/base.scss
@@ -49,8 +49,6 @@ body { // stylelint-disable-line
 
   // iOS on orientation change
   text-size-adjust: 100%;
-
-  overflow-x: hidden;
 }
 
 img { // stylelint-disable-line

--- a/shared/styles/base.scss
+++ b/shared/styles/base.scss
@@ -17,7 +17,7 @@
 html, body { // stylelint-disable-line
   min-height: 100vh;
 
-  background: #fff;
+  background: $color-background;
 }
 
 html { // stylelint-disable-line
@@ -45,7 +45,7 @@ body { // stylelint-disable-line
   font-family: $font-family;
   font-size: $font-size;
   line-height: $line-height;
-  color: $color-default;
+  color: $color-font;
 
   // iOS on orientation change
   text-size-adjust: 100%;

--- a/shared/styles/base.scss
+++ b/shared/styles/base.scss
@@ -2,11 +2,12 @@
 *  This file is imported in components/app-layout/AppLayout.scss
 */
 
-@-ms-viewport { // stylelint-disable-line
+/* stylelint-disable selector-max-type  */
+@-ms-viewport {
   width: device-width;
 }
 
-@-o-viewport { // stylelint-disable-line
+@-o-viewport {
   width: device-width;
 }
 
@@ -14,13 +15,17 @@
   width: device-width;
 }
 
-html, body { // stylelint-disable-line
+html,
+body {
   min-height: 100vh;
 
   background: $color-background;
 }
 
-html { // stylelint-disable-line
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
   -webkit-overflow-scrolling: touch;
 
   overflow-x: hidden;
@@ -28,9 +33,6 @@ html { // stylelint-disable-line
   overflow-y: scroll;
 
   box-sizing: border-box;
-
-  -webkit-font-smoothing: antialiased; // stylelint-disable-line
-  -moz-osx-font-smoothing: grayscale; // stylelint-disable-line
 }
 
 // inherited from <html>
@@ -40,7 +42,7 @@ html { // stylelint-disable-line
   box-sizing: inherit;
 }
 
-body { // stylelint-disable-line
+body {
   position: relative;
 
   margin: 0;
@@ -54,24 +56,26 @@ body { // stylelint-disable-line
   text-size-adjust: 100%;
 }
 
-img { // stylelint-disable-line
+img {
   display: block;
   max-width: 100%;
   height: auto;
 }
 
 // placeholders
-input, textarea, select { // stylelint-disable-line
-  &::-webkit-input-placeholder { // stylelint-disable-line
+input,
+textarea,
+select {
+  &::-webkit-input-placeholder {
     color: $color-placeholder;
   }
 
-  &::-moz-placeholder { // stylelint-disable-line
+  &::-moz-placeholder {
     opacity: 1;
     color: $color-placeholder;
   }
 
-  &:-ms-input-placeholder { // stylelint-disable-line
+  &:-ms-input-placeholder {
     color: $color-placeholder;
   }
 }

--- a/shared/styles/base.scss
+++ b/shared/styles/base.scss
@@ -15,6 +15,20 @@
   width: device-width;
 }
 
+:root {
+  --scale-multiplier: $scale;
+
+  // 805px is start of 15" Mac Book Pro range
+  @media (max-height: 805px) and (min-aspect-ratio: 16/10) {
+    --scale-multiplier: $scale-md;
+  }
+
+  // 650px is start of 13" Mac Book Pro with dock at bottom range
+  @media (max-height: 650px) and (min-aspect-ratio: 16/10) {
+    --scale-multiplier: $scale-sm;
+  }
+}
+
 html,
 body {
   min-height: 100vh;

--- a/shared/styles/grid.scss
+++ b/shared/styles/grid.scss
@@ -1,14 +1,14 @@
 // Helper to convert straight number to percentage
 @function convertify($number) {
   @if type-of($number) == 'number' and unitless($number) {
-    @return percentage($number/12);
+    @return percentage($number / $grid-column-count);
   }
 
   @return $number;
 }
 
 // Rows
-@mixin make-row($direction: ltr, $align: stretch, $justify: flex-start, $grid-gutter: $gutter, $wrap: wrap) {
+@mixin grid-row($direction: ltr, $align: stretch, $justify: flex-start, $grid-gutter: $gutter, $wrap: wrap) {
   display: flex;
   flex-wrap: $wrap;
 
@@ -28,7 +28,7 @@
 }
 
 // Columns
-@mixin make-col($width: 100%, $align: stretch, $grid-gutter: $gutter) {
+@mixin grid-col($width: 100%, $align: stretch, $grid-gutter: $gutter) {
   flex: none;
   align-self: $align;
 
@@ -39,10 +39,31 @@
 }
 
 // Offsets
-@mixin make-offset-left($offset: percentage(1/12)) {
+@mixin grid-offset-left($offset: percentage(1/$grid-column-count)) {
   margin-left: convertify($offset);
 }
 
-@mixin make-offset-right($offset: percentage(1/12)) {
+@mixin grid-offset-right($offset: percentage(1/$grid-column-count)) {
   margin-right: convertify($offset);
+}
+
+// Deprecated mixins
+@mixin make-row($direction: ltr, $align: stretch, $justify: flex-start, $grid-gutter: $gutter, $wrap: wrap) {
+  @warn 'make-row mixin is deprecated, use grid-row';
+  @include grid-row($direction, $align, $justify, $grid-gutter, $wrap);
+}
+
+@mixin make-col($width: 100%, $align: stretch, $grid-gutter: $gutter) {
+  @warn 'make-col mixin is deprecated, use grid-col';
+  @include grid-col($width, $align, $grid-gutter);
+}
+
+@mixin make-offset-left($offset: percentage(1/$grid-column-count)) {
+  @warn 'make-offset-left mixin is deprecated, use grid-offset-left';
+  @include grid-offset-left($offset);
+}
+
+@mixin make-offset-right($offset: percentage(1/$grid-column-count)) {
+  @warn 'make-offset-right mixin is deprecated, use grid-offset-right';
+  @include grid-offset-right($offset);
 }

--- a/shared/styles/grid.scss
+++ b/shared/styles/grid.scss
@@ -39,11 +39,11 @@
 }
 
 // Offsets
-@mixin grid-offset-left($offset: percentage(1/$grid-column-count)) {
+@mixin grid-offset-left($offset: 1) {
   margin-left: convertify($offset);
 }
 
-@mixin grid-offset-right($offset: percentage(1/$grid-column-count)) {
+@mixin grid-offset-right($offset: 1) {
   margin-right: convertify($offset);
 }
 

--- a/shared/styles/grid.scss
+++ b/shared/styles/grid.scss
@@ -48,22 +48,22 @@
 }
 
 // Deprecated mixins
-@mixin make-row($direction: ltr, $align: stretch, $justify: flex-start, $grid-gutter: $gutter, $wrap: wrap) {
+@mixin make-row($args...) {
   @warn 'make-row mixin is deprecated, use grid-row';
-  @include grid-row($direction, $align, $justify, $grid-gutter, $wrap);
+  @include grid-row($args...);
 }
 
-@mixin make-col($width: 100%, $align: stretch, $grid-gutter: $gutter) {
+@mixin make-col($args...) {
   @warn 'make-col mixin is deprecated, use grid-col';
-  @include grid-col($width, $align, $grid-gutter);
+  @include grid-col($args...);
 }
 
-@mixin make-offset-left($offset: percentage(1/$grid-column-count)) {
+@mixin make-offset-left($args...) {
   @warn 'make-offset-left mixin is deprecated, use grid-offset-left';
-  @include grid-offset-left($offset);
+  @include grid-offset-left($args...);
 }
 
-@mixin make-offset-right($offset: percentage(1/$grid-column-count)) {
+@mixin make-offset-right($args...) {
   @warn 'make-offset-right mixin is deprecated, use grid-offset-right';
-  @include grid-offset-right($offset);
+  @include grid-offset-right($args...);
 }

--- a/shared/styles/mixins.scss
+++ b/shared/styles/mixins.scss
@@ -20,6 +20,10 @@
   $font-multiplier: (($size - $min-size) / (strip-unit($limit) - strip-unit($baseline)));
   $font-baseline: ($min-size - $font-multiplier * strip-unit($baseline));
 
+  @if $min-size >= $size {
+    @warn 'Responsive font: min-size equal or greater than size'
+  }
+
   font-size: #{$min-size}px;
 
   @media (min-width: $baseline) {

--- a/shared/styles/mixins.scss
+++ b/shared/styles/mixins.scss
@@ -15,8 +15,8 @@
 }
 
 // defaults to standard heading size
-@mixin responsive-font($min-size: 23, $size: 36, $limit: 1200px) {
-  $baseline: 375px;
+@mixin responsive-font($min-size: $font-size, $size: $font-size, $limit: $page-limit) {
+  $baseline: $min-mobile;
   $font-multiplier: (($size - $min-size) / (strip-unit($limit) - strip-unit($baseline)));
   $font-baseline: ($min-size - $font-multiplier * strip-unit($baseline));
 

--- a/shared/styles/mixins.scss
+++ b/shared/styles/mixins.scss
@@ -102,12 +102,14 @@
   }
 
   @media (min-width: $min-tablet) {
-    padding: 0 $container-gutter-tablet;
+    padding-left: $container-gutter-tablet;
+    padding-right: $container-gutter-tablet;
     max-width: $page-width + $container-gutter-tablet * 2;
   }
 
   @media (min-width: $min-desktop) {
-    padding: 0 $container-gutter-desktop;
+    padding-left: $container-gutter-desktop;
+    padding-right: $container-gutter-desktop;
     max-width: $page-width + $container-gutter-desktop * 2;
   }
 }

--- a/shared/styles/mixins.scss
+++ b/shared/styles/mixins.scss
@@ -15,7 +15,7 @@
 }
 
 // defaults to standard heading size
-@mixin responsive-font($min-size: $font-size, $size: $font-size, $limit: $page-limit) {
+@mixin responsive-font($min-size: ($font-size - 2), $size: $font-size, $limit: $page-limit) {
   $baseline: $min-mobile;
   $font-multiplier: (($size - $min-size) / (strip-unit($limit) - strip-unit($baseline)));
   $font-baseline: ($min-size - $font-multiplier * strip-unit($baseline));
@@ -63,14 +63,22 @@
   }
 }
 
+@mixin retina {
+  @media only screen and (-webkit-min-device-pixel-ratio: 1.3),
+    only screen and (-o-min-device-pixel-ratio: 13/10),
+    only screen and (min-resolution: 120dpi) {
+    @content;
+  }
+}
+
 // segment customisable per-component / instance rather than being forced to work around defaults.
 @mixin segment($padding-top: $segment-padding, $padding-bottom: $segment-padding, $padding-top-mobile: $segment-padding-mobile, $padding-bottom-mobile: $segment-padding-mobile) {
   padding-top: $padding-top-mobile;
   padding-bottom: $padding-bottom-mobile;
 
   @media (min-width: $min-tablet) {
-    padding-top: percentage(strip-unit($padding-top)/strip-unit($limit));
-    padding-bottom: percentage(strip-unit($padding-bottom)/strip-unit($limit));
+    padding-top: percentage(strip-unit($padding-top) / strip-unit($limit));
+    padding-bottom: percentage(strip-unit($padding-bottom) / strip-unit($limit));
   }
 
   @media (min-width: $limit) {

--- a/shared/styles/mixins.scss
+++ b/shared/styles/mixins.scss
@@ -81,11 +81,11 @@
   padding-bottom: $padding-bottom-mobile;
 
   @media (min-width: $min-tablet) {
-    padding-top: percentage(strip-unit($padding-top) / strip-unit($limit));
-    padding-bottom: percentage(strip-unit($padding-bottom) / strip-unit($limit));
+    padding-top: percentage(strip-unit($padding-top) / strip-unit($page-limit));
+    padding-bottom: percentage(strip-unit($padding-bottom) / strip-unit($page-limit));
   }
 
-  @media (min-width: $limit) {
+  @media (min-width: $page-limit) {
     padding-top: strip-unit($padding-top) * 1px;
     padding-bottom: strip-unit($padding-bottom) * 1px;
   }

--- a/shared/styles/mixins.scss
+++ b/shared/styles/mixins.scss
@@ -111,3 +111,53 @@
     max-width: $page-width + $container-gutter-desktop * 2;
   }
 }
+
+// change below to reflect your project
+// numerical values are arbitrary
+@mixin heading($min: ($font-size * 1.5), $max: ($font-size * 3)) {
+  @include reset-heading;
+  @include responsive-font($min, $max);
+
+  @warn 'Please implement for project';
+
+  margin-bottom: (5/$max)*1em;
+
+  font-family: $font-family;
+  font-weight: normal;
+  letter-spacing: 0;
+  line-height: (58/$max);
+
+  color: $color-font;
+}
+
+@mixin subheading($min: ($font-size * 1.5), $max: ($font-size * 3)) {
+  @include reset-heading;
+  @include responsive-font($min, $max);
+
+  @warn 'Please implement for project';
+
+  margin-bottom: (26/$max) * 1em;
+
+  font-family: $font-family;
+  font-weight: normal;
+  letter-spacing: 0;
+  line-height: (58/52);
+
+  color: $color-font;
+}
+
+@mixin copy($min: $font-size, $max: ($font-size + 4)) {
+  @include reset-all;
+  @include responsive-font($min, $max);
+
+  @warn 'Please implement for project';
+
+  margin-bottom: (26/$max) * 1em;
+
+  font-family: $font-family;
+  font-weight: normal;
+  letter-spacing: 0;
+  line-height: (58/$max);
+
+  color: $color-font;
+}

--- a/shared/styles/mixins.scss
+++ b/shared/styles/mixins.scss
@@ -33,6 +33,8 @@
 }
 
 @mixin viewport($media) {
+  @warn 'viewport mixin is deprecated and will be removed in a future version';
+
   @if $media == handset {
     @media only screen and (max-width: $min-600) { @content; }
   }
@@ -83,7 +85,7 @@
   padding: 0 $container-gutter-mobile;
   max-width: $page-width + $container-gutter-mobile * 1;
 
-  @media (min-width: 340px) {
+  @media (min-width: $min-mobile) {
     max-width: $page-width + $container-gutter-mobile * 2;
   }
 

--- a/shared/styles/mixins.scss
+++ b/shared/styles/mixins.scss
@@ -145,7 +145,7 @@
   font-family: $font-family;
   font-weight: normal;
   letter-spacing: 0;
-  line-height: (58/52);
+  line-height: (58/$max);
 
   color: $color-font;
 }

--- a/shared/styles/mixins.scss
+++ b/shared/styles/mixins.scss
@@ -21,7 +21,7 @@
   $font-baseline: ($min-size - $font-multiplier * strip-unit($baseline));
 
   @if $min-size >= $size {
-    @warn 'Responsive font: min-size equal or greater than size'
+    @warn 'Responsive font: min-size equal or greater than size';
   }
 
   font-size: #{$min-size}px;

--- a/shared/styles/mixins.scss
+++ b/shared/styles/mixins.scss
@@ -96,7 +96,9 @@
 @mixin container() {
   margin: 0 auto;
 
-  padding: 0 $container-gutter-mobile;
+  padding-left: $container-gutter-mobile;
+  padding-right: $container-gutter-mobile;
+
   max-width: $page-width + $container-gutter-mobile * 1;
 
   @media (min-width: $min-mobile) {
@@ -117,19 +119,19 @@
 }
 
 // change below to reflect your project
-// numerical values are arbitrary
 @mixin heading($min: ($font-size * 1.5), $max: ($font-size * 3)) {
   @include reset-heading;
   @include responsive-font($min, $max);
 
-  @warn 'Please implement for project';
+  $arbitrary-heading-margin: 5;
+  $arbitrary-heading-line-height: 58;
 
-  margin-bottom: (5/$max)*1em;
+  margin-bottom: ($arbitrary-heading-margin/$max) * 1em;
 
   font-family: $font-family;
   font-weight: normal;
   letter-spacing: 0;
-  line-height: (58/$max);
+  line-height: ($arbitrary-heading-line-height/$max);
 
   color: $color-font;
 }
@@ -138,14 +140,15 @@
   @include reset-heading;
   @include responsive-font($min, $max);
 
-  @warn 'Please implement for project';
+  $arbitrary-subheading-margin: 26;
+  $arbitrary-subheading-line-height: 58;
 
-  margin-bottom: (26/$max) * 1em;
+  margin-bottom: ($arbitrary-subheading-margin/$max) * 1em;
 
   font-family: $font-family;
   font-weight: normal;
   letter-spacing: 0;
-  line-height: (58/52);
+  line-height: ($arbitrary-subheading-line-height/$max);
 
   color: $color-font;
 }
@@ -154,14 +157,15 @@
   @include reset-all;
   @include responsive-font($min, $max);
 
-  @warn 'Please implement for project';
+  $arbitrary-copy-margin: 26;
+  $arbitrary-copy-line-height: 58;
 
-  margin-bottom: (26/$max) * 1em;
+  margin-bottom: ($arbitrary-copy-margin/$max) * 1em;
 
   font-family: $font-family;
   font-weight: normal;
   letter-spacing: 0;
-  line-height: (58/$max);
+  line-height: ($arbitrary-copy-line-height/$max);
 
   color: $color-font;
 }

--- a/shared/styles/mixins.scss
+++ b/shared/styles/mixins.scss
@@ -25,14 +25,16 @@
   }
 
   font-size: #{$min-size}px;
+  font-size: calc(#{$min-size}px * #{var(--scale-multiplier)});
 
   @media (min-width: $baseline) {
     font-size: #{$min-size}px;
-    font-size: calc(#{$font-multiplier} * #{100vw} + (#{$font-baseline}px));
+    font-size: calc((#{$font-multiplier} * #{100vw} + (#{$font-baseline}px)) * #{var(--scale-multiplier)});
   }
 
   @media (min-width: $limit) {
     font-size: #{$size}px;
+    font-size: calc(#{$size}px * #{var(--scale-multiplier)});
   }
 }
 

--- a/shared/styles/reset.scss
+++ b/shared/styles/reset.scss
@@ -3,6 +3,7 @@
   margin: 0;
 
   font-family: inherit;
+  font-style: inherit;
   font-size: inherit;
   font-weight: inherit;
   line-height: inherit;

--- a/shared/styles/variables.scss
+++ b/shared/styles/variables.scss
@@ -9,7 +9,7 @@ $grid-baseline: 16px;
 
 // page dimensions
 $page-width: 1230px;
-$limit: $page-width + ($container-gutter-desktop * 2);
+$page-limit: $page-width + ($container-gutter-desktop * 2);
 
 // Fonts
 $font-family: 'Roboto', sans-serif;
@@ -17,7 +17,8 @@ $font-size: 16px;
 $line-height: 1.5;
 
 // Colors
-$color-default: #333;
+$color-font: #333;
+$color-background: #fff;
 $color-light: #777;
 $color-dark: #111;
 $color-pink: #aa0078;
@@ -44,6 +45,7 @@ $min-600: 600px;
 $min-560: 560px;
 $min-540: 540px;
 $min-480: 480px;
+$min-420: 420px;
 $min-375: 375px;
 $min-360: 360px;
 
@@ -60,6 +62,7 @@ $max-640: 639px;
 $max-600: 599px;
 $max-540: 539px;
 $max-480: 479px;
+$max-420: 419px;
 $max-375: 374px;
 $max-360: 359px;
 

--- a/shared/styles/variables.scss
+++ b/shared/styles/variables.scss
@@ -67,7 +67,7 @@ $max-375: 374px;
 $max-360: 359px;
 
 // Predefined breakpoints
-$min-mobile: $min-480;
+$min-mobile: $min-420;
 $min-tablet: $min-720;
 $min-desktop: $min-1080;
 

--- a/shared/styles/variables.scss
+++ b/shared/styles/variables.scss
@@ -8,7 +8,7 @@ $grid-column-count: 12;
 $grid-baseline: 16px;
 
 // page dimensions
-$page-width: 1230px;
+$page-width: 1290px;
 $page-limit: $page-width + ($container-gutter-desktop * 2);
 
 // Fonts

--- a/shared/styles/variables.scss
+++ b/shared/styles/variables.scss
@@ -3,6 +3,10 @@ $container-gutter-mobile: $gutter;
 $container-gutter-tablet: 50px;
 $container-gutter-desktop: 70px;
 
+// grid
+$grid-column-count: 12;
+$grid-baseline: 16px;
+
 // page dimensions
 $page-width: 1230px;
 $limit: $page-width + ($container-gutter-desktop * 2);

--- a/shared/styles/variables.scss
+++ b/shared/styles/variables.scss
@@ -74,3 +74,9 @@ $min-desktop: $min-1080;
 // Segment
 $segment-padding-mobile: $gutter * 3;
 $segment-padding: 200px; //percentage-based segments spacing
+
+// scale for edge-case wide pages
+// used in :root in base.scss
+$scale: 1;
+$scale-md: 0.9;
+$scale-sm: 0.8;


### PR DESCRIPTION
Changes to default Sass:

* Add scaling css var and calc to responsive-font to deal with wide pages
* Move hardcoded values to variables
* Deprecate `viewport` mixin via `@warn`
* Update `$min-mobile` breakpoint to 420 from 480
* Update `$page-width` to `1290px`
* Rename (and deprecate old) grid mixins to `grid-col` etc
* Add heading() subheading and copy() mixinstemplates
