### PR TITLE
Removed core-decorators package

### DIFF
--- a/config/values.js
+++ b/config/values.js
@@ -321,7 +321,6 @@ const values = {
           'react-router-dom',
           'mobx',
           'mobx-react',
-          'core-decorators',
         ],
 
         // The name of the vendor DLL.

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "classnames-loader": "2.0.0",
     "colors": "1.1.2",
     "compression": "1.7.0",
-    "core-decorators": "0.19.0",
     "cross-env": "5.0.5",
     "css-loader": "0.28.5",
     "dotenv": "4.0.0",

--- a/shared/components/devtools/DevTools.js
+++ b/shared/components/devtools/DevTools.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import { observable } from 'mobx';
 import { observer } from 'mobx-react';
-import autobind from 'core-decorators/lib/autobind';
 import config from 'utils/config';
 
 const showDevTools = process.env.BUILD_FLAG_IS_DEV === 'true' || config('herokuDevtools');
@@ -24,15 +23,13 @@ class DevTools extends PureComponent {
     document.removeEventListener('keydown', this.keydownRef);
   }
 
-  @autobind
-  onKeyDown(e) {
+  onKeyDown = (e) => {
     if (e.ctrlKey && e.keyCode === 75) {
       this.onToggleDisplay();
     }
   }
 
-  @autobind
-  onToggleDisplay() {
+  onToggleDisplay = () => {
     this.display = !this.display;
 
     localStorage.setItem(LOCAL_STORAGE_KEY_VISIBLE, this.display);

--- a/shared/components/grid-overlay/GridOverlay.js
+++ b/shared/components/grid-overlay/GridOverlay.js
@@ -3,7 +3,6 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { observable } from 'mobx';
 import { observer } from 'mobx-react';
-import autobind from 'core-decorators/lib/autobind';
 
 import s from './GridOverlay.scss';
 
@@ -69,8 +68,7 @@ export default class GridOverlay extends PureComponent {
    * Because why not
    * @return {void}
    */
-  @autobind
-  onKeyDown(e) {
+  onKeyDown = (e) => {
     if (e.ctrlKey && e.keyCode === 76) {
       this.onToggleVertical();
     }
@@ -80,8 +78,7 @@ export default class GridOverlay extends PureComponent {
    * Fired when the horizontal grid is meant to be toggled.
    * @return {void}
    */
-  @autobind
-  onToggleHorizontal() {
+  onToggleHorizontal = () => {
     this.isHorizontalVisible = !this.isHorizontalVisible;
     localStorage.setItem(LOCAL_STORAGE_KEY_HORIZONTAL, this.isHorizontalVisible);
   }
@@ -90,8 +87,7 @@ export default class GridOverlay extends PureComponent {
    * Fired when the vertical grid is meant to be toggled.
    * @return {void}
    */
-  @autobind
-  onToggleVertical() {
+  onToggleVertical = () => {
     this.isVerticalVisible = !this.isVerticalVisible;
     localStorage.setItem(LOCAL_STORAGE_KEY_VERTICAL, this.isVerticalVisible);
   }

--- a/shared/routes/planets/list/PlanetsList.js
+++ b/shared/routes/planets/list/PlanetsList.js
@@ -5,7 +5,6 @@ import { computed } from 'mobx';
 import { withJob } from 'react-jobs';
 import { Link } from 'react-router-dom';
 import Helmet from 'react-helmet';
-import autobind from 'core-decorators/lib/autobind';
 
 import Segment from 'components/segment';
 import Button from 'components/button';
@@ -47,8 +46,7 @@ class Planets extends PureComponent {
    * @param {Event} Click-event.
    * @return {void}
    */
-  @autobind
-  onClickPage(e) {
+  onClickPage = (e) => {
     // Prevent default click behaviour
     e.preventDefault();
 

--- a/shared/store/Network.js
+++ b/shared/store/Network.js
@@ -1,5 +1,4 @@
 import { observable, ObservableMap, toJS } from 'mobx';
-import autobind from 'core-decorators/lib/autobind';
 import axios, { CancelToken } from 'axios';
 
 /**
@@ -25,8 +24,7 @@ export default class Network {
    * @param {object} Options
    * @return {Promise}
    */
-  @autobind
-  fetch(url, { maxAge = Infinity, force = false, ...rest } = {}) {
+  fetch = (url, { maxAge = Infinity, force = false, ...rest } = {}) => {
     const { history } = this;
 
     if (!history.has(url)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,10 +1950,6 @@ cookiejar@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
 
-core-decorators@0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/core-decorators/-/core-decorators-0.19.0.tgz#28c9b44aa6208902934627a28f4f5950bd5b463e"
-
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"


### PR DESCRIPTION
We're only including core-decorators package for `autobind`. Most of us prefer the public class fields syntax: `something = () => {}`.