### PR TITLE
Windows fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "dev-remote": "cross-env DEPLOYMENT=development babel-node internal/scripts/ngrok",
     "fix-sass": "npm rebuild node-sass",
     "preinstall": "node internal/scripts/preinstall",
-    "postinstall": "if [ \"x$NODE_ENV\" != \"x\" ] && [ \"$NODE_ENV\" != \"development\" ]; then (npm run fix-sass && npm run build); fi;",
     "start": "cross-env NODE_ENV=production node build/server",
     "start:static": "serve build/static",
     "lint": "npm run eslint; npm run stylelint",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "deploy": "babel-node internal/scripts/deploy",
     "dev": "cross-env DEPLOYMENT=development babel-node internal/development",
     "dev-remote": "cross-env DEPLOYMENT=development babel-node internal/scripts/ngrok",
-    "fix-sass": "npm rebuild node-sass",
     "preinstall": "node internal/scripts/preinstall",
     "heroku-postbuild": "npm run build",
     "start": "cross-env NODE_ENV=production node build/server",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dev-remote": "cross-env DEPLOYMENT=development babel-node internal/scripts/ngrok",
     "fix-sass": "npm rebuild node-sass",
     "preinstall": "node internal/scripts/preinstall",
+    "heroku-postbuild": "npm run build",
     "start": "cross-env NODE_ENV=production node build/server",
     "start:static": "serve build/static",
     "lint": "npm run eslint && npm run stylelint",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "preinstall": "node internal/scripts/preinstall",
     "start": "cross-env NODE_ENV=production node build/server",
     "start:static": "serve build/static",
-    "lint": "npm run eslint; npm run stylelint",
+    "lint": "npm run eslint && npm run stylelint",
     "lint-staged": "lint-staged",
     "eslint": "eslint client server shared config internal --report-unused-disable-directives",
     "stylelint": "stylelint \"shared/**/*.scss\" --syntax scss",


### PR DESCRIPTION
Small fixes that get rid of an error when running postinstall (but it still works) and allows for `npm run lint` to work.

Postinstall node-sass rebuild should not be required anymore