### PR TITLE
Ie compatibility mode support

### DIFF
--- a/config/values.js
+++ b/config/values.js
@@ -128,7 +128,7 @@ const values = {
         http://realfavicongenerator.net/
         http://www.favicomatic.com/
       */
-      { 'http-equiv': 'X-UA-Compatible', content: 'IE=edge' },
+      { charset: 'utf-8' },
       { name: 'description', content: 'Ueno. description text here!' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1, user-scalable=no' }, // prevents inputs from zooming, but iOS still allows normal pinch zoom
       { name: 'msapplication-TileColor', content: '#00E2AD' },

--- a/server/middleware/reactApplication/ServerHTML.js
+++ b/server/middleware/reactApplication/ServerHTML.js
@@ -70,6 +70,8 @@ function ServerHTML(props) {
   } = getChunks(chunkNames);
 
   const headerElements = removeNil([
+    // IE wants this at the top of the head element before any script tags
+    <meta httpEquiv="X-UA-Compatible" content="IE=edge" />,
     // Renames html class from no-js to js
     inlineScript('var e=document.documentElement;e.className=e.className.replace("no-js","js")'),
     ifElse(facebookPixel)(() => inlineScript(analytics.facebook)),


### PR DESCRIPTION
When IE is in compatibility mode it uses an IE7 user-agent identifier in get requests, even if it's using IE11 features.  This was causing our call to polyfill.io to fail because IE7 support wasn't required or sufficient, but was being requested.

This PR changes the polyfill.io call by waiting until runtime and checking if the browser is IE before constructing the polyfill IO URL. In the case of IE, it uses the IE specific documentMode to construct the URL. 

You can see the issues by using IE11 and choosing Tools | Compatibility Mode Settings and browsing to 
https://starter-kit-universally.herokuapp.com/     BROKEN
https://starter-kit-universally-pr-87.herokuapp.com/    FIXED