### PR TITLE
Improve error handling

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -11,6 +11,7 @@ import Store from 'store';
 import App from 'App';
 
 import config from 'utils/config';
+import ErrorBoundary from 'components/error-boundary';
 import ReactHotLoader from './components/ReactHotLoader';
 
 // Initialize Google Analytics
@@ -47,18 +48,25 @@ function renderApp(TheApp) {
   // component app with a browser based version of react router.
   const app = (
     <ReactHotLoader>
-      <JobProvider rehydrateState={rehydrateState}>
-        <Provider {...store}>
-          <BrowserRouter forceRefresh={!supportsHistory}>
-            <TheApp />
-          </BrowserRouter>
-        </Provider>
-      </JobProvider>
+      <ErrorBoundary>
+        <JobProvider rehydrateState={rehydrateState}>
+          <Provider {...store}>
+            <BrowserRouter forceRefresh={!supportsHistory}>
+              <TheApp />
+            </BrowserRouter>
+          </Provider>
+        </JobProvider>
+      </ErrorBoundary>
     </ReactHotLoader>
   );
 
   // Needed for react-jobs
-  asyncBootstrapper(app).then(() => hydrate(app, container));
+  asyncBootstrapper(app)
+    .then(() => hydrate(app, container))
+    .catch((err) => {
+      console.warn('Error bootstrapping react app', err);
+      throw err;
+    });
 }
 
 // Execute the first render of our app.

--- a/server/middleware/errorHandlers.js
+++ b/server/middleware/errorHandlers.js
@@ -3,6 +3,9 @@
 
 const prettyError = require('pretty-error').start();
 
+// default color scheme has a very low contrast in light terminal themes
+prettyError.withoutColors();
+
 // Configure prettyError to simplify the stack trace:
 
 // skip events.js and http.js and similar core node files

--- a/shared/components/error-boundary/ErrorBoundary.js
+++ b/shared/components/error-boundary/ErrorBoundary.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+export default class ErrorBoundary extends Component {
+
+  static propTypes = {
+    children: PropTypes.node,
+  }
+
+  state = {
+    error: null,
+    errorInfo: null,
+  };
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({
+      error,
+      errorInfo,
+    });
+  }
+
+  render() {
+    if (this.state.errorInfo) {
+      return (
+        <div>
+          <h2>Error</h2>
+          <p>{this.state.error && this.state.error.toString()}</p>
+          <pre>{this.state.errorInfo.componentStack}</pre>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/shared/components/error-boundary/index.js
+++ b/shared/components/error-boundary/index.js
@@ -1,0 +1,1 @@
+export default from './ErrorBoundary';


### PR DESCRIPTION
* Turn of color theme for pretty-errors, I can't read the errors in my lightly-themed terminal because of low contrast
* Add ErrorBoundary component for client render
* Add catch() to SSR render

Should get rid of the pesky

```
SERVER: Error in server execution, check the console for more info.
(node:59606) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:59606) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

errors, which are most often triggered by some errors in the store but the errors get eaten and you're left going 🤔

Test by e.g. commenting out this line
https://github.com/ueno-llc/starter-kit-universally/blob/error-handling/shared/store/index.js#L8